### PR TITLE
Fix KeyError when manufacturer missing in Hive device data

### DIFF
--- a/custom_components/hive/__init__.py
+++ b/custom_components/hive/__init__.py
@@ -149,7 +149,7 @@ class HiveEntity(Entity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.device["device_id"])},
             model=self.device["deviceData"]["model"],
-            manufacturer=self.device["deviceData"]["manufacturer"],
+            manufacturer=self.device.get("deviceData", {}).get("manufacturer", "Hive"),
             name=self.device["device_name"],
             sw_version=self.device["deviceData"]["version"],
             via_device=(DOMAIN, self.device["parentDevice"]),


### PR DESCRIPTION
When setting up my integration, it was failing to locate devices. The logs showed some of my devices had no manufacturer. This fixes a KeyError that occurs when Hive devices don't have manufacturer data in their deviceData dictionary.

- This occurs when the Hive API returns device data without a "manufacturer" field
- Changed to use `.get()` method with default fallback value "Hive"
- Tested with Hive devices that have missing manufacturer data

Related PR https://github.com/home-assistant/core/pull/154324